### PR TITLE
remove grep which is not supported in Win OS, change to path regexp

### DIFF
--- a/src/Composer/templates/git/hooks/pre-commit-phpcs
+++ b/src/Composer/templates/git/hooks/pre-commit-phpcs
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # get changed .php files, ready to be commited, all but deleted
-FILES=$(git diff --name-only --cached --diff-filter=ACMRTUXB | grep .php);
+FILES=$(git diff --name-only --cached --diff-filter=ACMRTUXB *.php);
 
 # run phpcs
 if [ ! -z "$FILES" ]; then


### PR DESCRIPTION
When I use it under Win OS, than I've problem with all files which I modified. That could help, but I don't have Linux for full test.